### PR TITLE
fix CloseViewRequest sample

### DIFF
--- a/docs/mvvm/built-in-messages.md
+++ b/docs/mvvm/built-in-messages.md
@@ -46,7 +46,7 @@ The following messages are broadcasted or dispatched by the infrastructure when 
 
       public void Sample()
       {
-          this.broker.Broadcast( this, new CloseViewRequest() );
+          this.broker.Broadcast( this, new CloseViewRequest( this ) );
       }
   }
   ```

--- a/docs/mvvm/built-in-messages.md
+++ b/docs/mvvm/built-in-messages.md
@@ -46,7 +46,7 @@ The following messages are broadcasted or dispatched by the infrastructure when 
 
       public void Sample()
       {
-          this.broker.Broadcast( new CloseViewRequest( this ) );
+          this.broker.Broadcast( this, new CloseViewRequest() );
       }
   }
   ```


### PR DESCRIPTION
as far as I remember this was the old format:

```csharp
this.broker.Broadcast( new CloseViewRequest( this ) );
```

that as been replace with the poco oriented format:

```csharp
this.broker.Broadcast( this, new CloseViewRequest( this ) );
```