### PR TITLE
Document preserve View DataContext on TabItem headers

### DIFF
--- a/docs/ui-composition/tabcontrol-region.md
+++ b/docs/ui-composition/tabcontrol-region.md
@@ -14,9 +14,46 @@ The `DependencyObject` we can add as content will be used as the `TabItem` conte
 <UserControl x:Class="SampleView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:rg="http://schemas.radicalframework.com/windows/presentation/regions"
-             rg:RegionHeaderedElement.Header="This will be used as header">
+             xmlns:rg="http://schemas.radicalframework.com/windows/presentation/regions">
+             <rg:RegionHeaderedElement.Header>
+                <TextBlock Text="This will be used as header" />
+             </rg:RegionHeaderedElement.Header>
+   <!-- user control content here -->
 </UserControl>
 ```
 
 The header is not constrained to be a string but can be any valid XAML content.
+
+### Header data context
+
+The WPF `TabItem` element has a `Header` and a `Content` property. The value of the `RegionHeaderedElement.Header` attached property is added the `TabItem.Header` property, this means that by default in the generated visual tree the tab item content and the tab item header don't share the same `DataContext`. Assuming a `TabView` view and a corresponding `TabViewModel` the following code snippet won't work as expected:
+
+```xaml
+<UserControl x:Class="TabView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:rg="http://schemas.radicalframework.com/windows/presentation/regions">
+             <rg:RegionHeaderedElement.Header>
+                <TextBlock Text="{Binding Path=PropertyOnTabViewMoodel}" />
+             </rg:RegionHeaderedElement.Header>
+   <!-- user control content here -->
+</UserControl>
+```
+
+At runtime Radical creates a `TabViewModel` instance and binds it to the `TabView` UserControl. When the user control is added as content to the TabItem the header is extracted from the attached property, at this point the TabItem header DataContext is inherited from the TabControl DataContex and the `PropertyOnTabViewMoodel` property won't be found.
+To make so that the header content has the same DataContext as the user control the `PreserveOwningRegionDataContext` attached property can be used:
+
+```xaml
+<UserControl x:Class="TabView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:rg="http://schemas.radicalframework.com/windows/presentation/regions"
+             rg:RegionHeaderedElement.PreserveOwningRegionDataContext="true">
+             <rg:RegionHeaderedElement.Header>
+                <TextBlock Text="{Binding Path=PropertyOnTabViewMoodel}" />
+             </rg:RegionHeaderedElement.Header>
+   <!-- user control content here -->
+</UserControl>
+```
+
+At runtime in the visual tree the TabItem header will have the user control DataContext. For backward compatibility reasons the default value of `PreserveOwningRegionDataContext` is `false`.


### PR DESCRIPTION
This can be merged only once Radical.Windows 2.1.0 is released

Documentation for https://github.com/RadicalFx/Radical.Windows/issues/237